### PR TITLE
Enable date and time settings for remote files

### DIFF
--- a/netmount-server/fs.hpp
+++ b/netmount-server/fs.hpp
@@ -117,6 +117,9 @@ public:
     /// Returns the size of file defined by handle (or -1 on error)
     int32_t get_file_size(uint16_t handle);
 
+    /// Throws exception on error
+    void set_file_date_time(uint16_t handle, uint32_t date_time);
+
     /// Searches for files matching template `tmpl` in directory defined by `handle`
     /// with at most attributes `attr`.
     /// Fills in `properties` with the next match after `nth` and updates `nth`

--- a/netmount-server/netmount-server.cpp
+++ b/netmount-server/netmount-server.cpp
@@ -262,9 +262,10 @@ int process_request(ReplyCache::ReplyInfo & reply_info, const uint8_t * request_
             // Only checking the existence of the handle because I don't keep files open.
             auto * const request = reinterpret_cast<const drive_proto_closef *>(request_data);
             const uint16_t handle = from_little16(request->start_cluster);
-            log(LogLevel::DEBUG, "CLOSE_FILE handle {}\n", handle);
+            const uint32_t date_time = from_little32(request->date_time);
+            log(LogLevel::DEBUG, "CLOSE_FILE handle {} {:08X}\n", handle, date_time);
             try {
-                drive.get_handle_path(handle);
+                drive.set_file_date_time(handle, date_time);
             } catch (const std::runtime_error & ex) {
                 log(LogLevel::WARNING, "CLOSE_FILE handle {}: {}\n", handle, ex.what());
                 // TODO: Send error to client?

--- a/netmount/netmount.c
+++ b/netmount/netmount.c
@@ -905,6 +905,7 @@ static void handle_request_for_our_drive(void) {
 
             struct drive_proto_closef * const args = (struct drive_proto_closef * const)buff;
             args->start_cluster = sftptr->start_cluster;
+            args->date_time = sftptr->file_time;
             if (send_request(subfunction, reqdrv, sizeof(*args), &reply, &ax) == 0) {
                 if (ax != 0) {
                     set_error(r, ax);

--- a/netmount/netmount.c
+++ b/netmount/netmount.c
@@ -905,7 +905,11 @@ static void handle_request_for_our_drive(void) {
 
             struct drive_proto_closef * const args = (struct drive_proto_closef * const)buff;
             args->start_cluster = sftptr->start_cluster;
-            args->date_time = sftptr->file_time;
+            if (sftptr->start_file_time != sftptr->file_time) {
+                args->date_time = sftptr->file_time;
+            } else {
+                args->date_time = 0;
+            }
             if (send_request(subfunction, reqdrv, sizeof(*args), &reply, &ax) == 0) {
                 if (ax != 0) {
                     set_error(r, ax);
@@ -1119,7 +1123,6 @@ static void handle_request_for_our_drive(void) {
                 }
                 *recvbufflen_ptr = 0;
             } while (bytes_left > 0);
-            sftptr->file_time = 0;
         } break;
 
         case INT2F_LOCK_UNLOCK_FILE: {
@@ -1361,8 +1364,7 @@ static void handle_request_for_our_drive(void) {
                 sft_ptr->file_pos = 0;
                 sft_ptr->open_mode &= 0xFF00U;
                 sft_ptr->open_mode |= args->mode;
-                sft_ptr->rel_sector = 0xFFFFU;
-                sft_ptr->abs_sector = 0xFFFFU;
+                sft_ptr->start_file_time = args->date_time;
                 sft_ptr->dir_sector = 0;
                 sft_ptr->dir_entry_no = 0xFF;  // why such value? no idea, EtherDFS says PHANTON.C uses that
                 sft_ptr->file_name = args->name;

--- a/netmount/netmount.c
+++ b/netmount/netmount.c
@@ -1119,6 +1119,7 @@ static void handle_request_for_our_drive(void) {
                 }
                 *recvbufflen_ptr = 0;
             } while (bytes_left > 0);
+            sftptr->file_time = 0;
         } break;
 
         case INT2F_LOCK_UNLOCK_FILE: {

--- a/shared/dos.h
+++ b/shared/dos.h
@@ -223,8 +223,13 @@ struct dos_sft {
     uint32_t file_time;      // file date and time
     uint32_t file_size;      // file length
     uint32_t file_pos;       // current file position
-    uint16_t rel_sector;
-    uint16_t abs_sector;
+    union {
+        struct {
+            uint16_t rel_sector;
+            uint16_t abs_sector;
+        };
+        uint32_t start_file_time;
+    };
     uint16_t dir_sector;
     uint8_t dir_entry_no;  // if local, number of directory entry within sector
     struct fcb_file_name file_name;

--- a/shared/drvproto.h
+++ b/shared/drvproto.h
@@ -36,6 +36,7 @@ struct drive_proto_hdr {
 
 struct drive_proto_closef {
     uint16_t start_cluster;
+    uint32_t date_time;
 };
 
 


### PR DESCRIPTION
int 21h ax=5701h updates the sft's file_time.
The file close packet adds the date/time information and sends the file_time to the server, which then sets the file's date/time information.
With this modification, the date and time information will also be copied when copying a file.